### PR TITLE
Allow PLC creation with non-default config path

### DIFF
--- a/ClockKit/ConfigReader.cpp
+++ b/ClockKit/ConfigReader.cpp
@@ -18,9 +18,9 @@
 namespace dex {
 
 #ifdef WIN32
-	const string DEFAULT_CONFIG_FILE_PATH = "C:\\clockkit.conf";
+    const string DEFAULT_CONFIG_FILE_PATH = "C:\\clockkit.conf";
 #else
-	const string DEFAULT_CONFIG_FILE_PATH = "/etc/clockkit.conf";
+    const string DEFAULT_CONFIG_FILE_PATH = "/etc/clockkit.conf";
 #endif
 
 PhaseLockedClock* PhaseLockedClockFromConfigFile(string filename)
@@ -34,7 +34,7 @@ PhaseLockedClock* PhaseLockedClockFromConfigFile(string filename)
     ifstream file(filename.c_str());
     if (!file.is_open())
         throw Exception("failed to open config file " + DEFAULT_CONFIG_FILE_PATH);
- 
+
     while (!file.eof())
     {
         string line;
@@ -43,7 +43,7 @@ PhaseLockedClock* PhaseLockedClockFromConfigFile(string filename)
         if (pos < 0) break;
         string name = line.substr(0,pos);
         string value = line.substr(pos+1);
-        
+
         if (name == "server")
         {
             server = value;
@@ -65,9 +65,10 @@ PhaseLockedClock* PhaseLockedClockFromConfigFile(string filename)
             updatePanic = atoi(value.c_str());
         }
     }
-    
+
     file.close();
 
+    //TODO separate printing from object creation
     cout << "config [server:" << server << "]" << endl;
     cout << "config [port:" << port << "]" << endl;
     cout << "config [timeout:" << timeout << "]" << endl;

--- a/ClockKit/clockkit.cpp
+++ b/ClockKit/clockkit.cpp
@@ -17,10 +17,18 @@ void ckInitialize()
     ckClock = dex::PhaseLockedClockFromConfigFile(dex::DEFAULT_CONFIG_FILE_PATH);
 }
 
+void ckInitializeFromConfig(const char *path)
+{
+    if (ckClock != NULL) return;
+    ckClock = dex::PhaseLockedClockFromConfigFile(std::string(path));
+}
+
 
 dex::timestamp_t ckTimeAsValue()
 {
-    ckInitialize();
+    /* Avoid error but at the same time allow manual calling of ckInitialize
+     * with non-default config */
+    if (ckClock == NULL) ckInitialize();
     try
     {
         return ckClock->getValue();
@@ -33,10 +41,10 @@ dex::timestamp_t ckTimeAsValue()
 
 const char* ckTimeAsString()
 {
-	ckInitialize();
-	try
+    if (ckClock == NULL) ckInitialize();
+    try
     {
-    	ckTimeString = dex::Timestamp::timestampToString( ckClock->getValue() );
+        ckTimeString = dex::Timestamp::timestampToString( ckClock->getValue() );
     }
     catch (dex::ClockException e)
     {
@@ -48,19 +56,19 @@ const char* ckTimeAsString()
 
 bool ckInSync()
 {
-	ckInitialize();
-	return ckClock->isSynchronized();
+    if (ckClock == NULL) ckInitialize();
+    return ckClock->isSynchronized();
 }
 
 int ckOffset()
 {
-	ckInitialize();
-	try
-	{
-		return ckClock->getOffset();
-	}
-	catch (dex::ClockException e)
-	{
-		return 0;	
-	}
+    if (ckClock == NULL) ckInitialize();
+    try
+    {
+        return ckClock->getOffset();
+    }
+    catch (dex::ClockException e)
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
Add `ckInitializeFromConfig` to allow feeding a non-default path to `ConfigReader`.

Does not have SWIG configuration for now.