### PR TITLE
Add missing forward declaration in header

### DIFF
--- a/ClockKit/clockkit.h
+++ b/ClockKit/clockkit.h
@@ -8,6 +8,7 @@
 #include "Common.h"
 
 extern void ckInitialize();
+extern void ckInitializeFromConfig(const char*);
 extern dex::timestamp_t ckTimeAsValue();
 extern const char* ckTimeAsString();
 extern bool ckInSync();


### PR DESCRIPTION
Add missing forward declaration to `clockkit.h`.